### PR TITLE
always pass rule as the second arg to visitor

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,6 @@ module.exports = function(node, fn){
     // @charset, @import etc
     if (!rule.declarations) return;
 
-    fn(rule.declarations, node);
+    fn(rule.declarations, rule);
   });
 };


### PR DESCRIPTION
`node` was being passed in, instead of `rule`.
